### PR TITLE
Fixed bug when running under Nodemon

### DIFF
--- a/messageClient.py
+++ b/messageClient.py
@@ -56,6 +56,7 @@ class Client:
 
     def prompt(self):
         sys.stdout.write("% ")
+        sys.stdout.flush()
 
     def parse_command(self,command):
         fields = command.split()


### PR DESCRIPTION
Added stdout.flush after prompt.
This still prints the % prompt without a newline, but allows for the client to be run with a tool such as nodemon where stdout is piped.